### PR TITLE
Hold YFactorCalibration's cal data in an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,19 +235,25 @@ The YFactorCalibration object requires the following:
 |name|required|type|unit|description|
 |----|--------------|-------|-------|-----------|
 |`last_time_performed`|true|datetime|[ISO-8601](https://github.com/gnuradio/SigMF/blob/master/sigmf-spec.md#the-datetime-pair)|Date and time of last calibration.|
-|`calibration_dictionary`|false|array|dB|A list of DEU attenuations with cooresponding calibration results. Calibration results are gain and noise figure arrays equal in length to the [`sample_count`](https://github.com/gnuradio/SigMF/blob/master/sigmf-spec.md#annotation-segment-objects).|   
+|`calibrations`|false|array|dB|DEU attenuations and cooresponding gain and noise figure arrays equal in length to the [`sample_count`](https://github.com/gnuradio/SigMF/blob/master/sigmf-spec.md#annotation-segment-objects).|   
 |`reference`|false|string|N/A|Data reference point, e.g., `"DEU input"`, `"antenna output"`, `"output of isotropic antenna"`.|
 
-An example `calibration_dictionary`, where "1" and "2" are DEU attenuation values:
+Example of `calibrations`:
+
 ```
-{ 1: { "gain" : [],
-       "noise_figure" : []
-     },
-  2: { "gain" : [],
-       "noise_figure" : []
-     },
+[
+  {
+    "attenuation": 1,
+    "gains": [],
+    "noise_levels": []
+  },
+  {
+    "attenuation": 2,
+    "gains": [],
+    "noise_levels": []
+  },
   ...
-}
+]
 ```
 
 #### 4.3.2 Dynamic Sensor Settings


### PR DESCRIPTION
I recommend changing `calibration_dictionary` to an array (like the type listed says it is). We should drop `_dictionary` in the name, since it's usually not a good idea to include types in variable names. There are 2 good reasons for using an array instead of an object:
 
 1) object are unordered, so although the example showed the attenuation values in order, the fact is that they would be in random order, which would make them difficult to read and impossible to sort. Including them as a field in the object means we can sort the array by attenuation value.
 2) If you use the object, the meaning of the keys is unclear without a statement such as "where '1' and '2' are DEU attenuation values." If you were to read the metadata without having this spec on hand, the structure could be misinterpreted.